### PR TITLE
externalize the deps

### DIFF
--- a/.changeset/light-chicken-build.md
+++ b/.changeset/light-chicken-build.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Improve build output by externalizing more dependencies in the Vite config.

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -57,8 +57,13 @@ export default defineConfig(({mode}) => {
       minify: false,
       rollupOptions: {
         external: (id, parentId) => {
-          // don't bundle these packages into our lib
-          // this creates a better build for node esm environments, but if we wanted a browser esm build, we would either have to tell devs to use "import maps" or to create a new bundle that doesn't use these as externals
+          /**
+           * Don't bundle these packages into our lib
+           *
+           * This creates a better build for node esm environments,
+           * but if we wanted a browser esm build, we would either have to tell devs to use "import maps"
+           * or to create a new bundle that doesn't use these as externals
+           * */
           if (parentId?.includes('@xstate') || id.includes('@xstate')) {
             return true;
           }

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -2,6 +2,7 @@
 import {resolve} from 'path';
 import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
+import packageJson from './package.json';
 
 export default defineConfig(({mode}) => {
   if (mode.includes('umdbuild')) {
@@ -55,8 +56,15 @@ export default defineConfig(({mode}) => {
       sourcemap: true,
       minify: false,
       rollupOptions: {
-        // don't bundle these packages into our lib
-        external: ['react', 'react-dom', 'react/jsx-runtime'],
+        external: (id, parentId) => {
+          // don't bundle these packages into our lib
+          // this creates a better build for node esm environments, but if we wanted a browser esm build, we would either have to tell devs to use "import maps" or to create a new bundle that doesn't use these as externals
+          if (parentId?.includes('@xstate') || id.includes('@xstate')) {
+            return true;
+          }
+
+          return externals.includes(id);
+        },
         output: {
           // keep the folder structure of the components in the dist folder
           preserveModules: true,
@@ -77,3 +85,10 @@ export default defineConfig(({mode}) => {
     },
   };
 });
+
+const externals = [
+  ...Object.keys(packageJson.dependencies),
+  ...Object.keys(packageJson.peerDependencies),
+  'react/jsx-runtime',
+  'worktop/cookie',
+];


### PR DESCRIPTION
This improves the build output to use the normal node_modules instead of a localized version that Vite creates for this packages. 

Note that in the current build, there's a `_virtual` and `node_modules` folder here https://unpkg.com/browse/@shopify/hydrogen-react@2022.10.1/dist/dev/

This update removes that