### PR TITLE
Create CartCost

### DIFF
--- a/.changeset/nine-eels-care.md
+++ b/.changeset/nine-eels-care.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Add `<CartCost/>` component

--- a/packages/react/src/CartCost.stories.tsx
+++ b/packages/react/src/CartCost.stories.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import type {Story} from '@ladle/react';
+import {CartCost} from './CartCost.js';
+import {CartProvider} from './CartProvider.js';
+import {CART_WITH_LINES} from './CartProvider.test.helpers.js';
+
+type CartCostProps = React.ComponentPropsWithoutRef<typeof CartCost>;
+
+const Template: Story<{amountType: CartCostProps['amountType']}> = (props) => {
+  return (
+    <CartProvider data={CART_WITH_LINES}>
+      <div>
+        cart.cost.totalAmount will be in the <CartCost amountType="total" />
+      </div>
+      <div>
+        cart.cost.totalAmount will be in the <CartCost amountType="subtotal" />
+      </div>
+      <div>
+        cart.cost.totalAmount will be in the <CartCost amountType="tax" />
+      </div>
+      <div>
+        cart.cost.totalAmount will be in the <CartCost amountType="duty" />
+      </div>
+      <hr />
+      <CartCost {...props} />
+    </CartProvider>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  amountType: 'total',
+};
+Default.argTypes = {
+  amountType: {
+    options: ['total', 'subtotal', 'tax', 'duty'],
+    control: {type: 'radio'},
+    defaultValue: 'total',
+  },
+};

--- a/packages/react/src/CartCost.test.tsx
+++ b/packages/react/src/CartCost.test.tsx
@@ -5,7 +5,6 @@ import {CartCost} from './CartCost.js';
 import {ComponentProps, PropsWithChildren} from 'react';
 import {ShopifyProvider} from './ShopifyProvider.js';
 import {getShopifyConfig} from './ShopifyProvider.test.js';
-import {vi} from 'vitest';
 
 const testId = 'cart-cost';
 

--- a/packages/react/src/CartCost.test.tsx
+++ b/packages/react/src/CartCost.test.tsx
@@ -1,0 +1,82 @@
+import {render, screen} from '@testing-library/react';
+import {CartProvider} from './CartProvider.js';
+import {CART_WITH_LINES} from './CartProvider.test.helpers.js';
+import {CartCost} from './CartCost.js';
+import {ComponentProps, PropsWithChildren} from 'react';
+import {ShopifyProvider} from './ShopifyProvider.js';
+import {getShopifyConfig} from './ShopifyProvider.test.js';
+import {vi} from 'vitest';
+
+const testId = 'cart-cost';
+
+function ShopifyCartProvider(
+  props: Omit<ComponentProps<typeof CartProvider>, 'children'> = {}
+) {
+  return function Wrapper({children}: PropsWithChildren) {
+    return (
+      <ShopifyProvider shopifyConfig={getShopifyConfig()}>
+        <CartProvider {...props}>{children}</CartProvider>
+      </ShopifyProvider>
+    );
+  };
+}
+
+describe('<CartCost />', () => {
+  it('renders total cost', () => {
+    render(<CartCost />, {
+      wrapper: ShopifyCartProvider({data: CART_WITH_LINES}),
+    });
+
+    expect(
+      screen.getByText(`CA$${CART_WITH_LINES.cost?.totalAmount?.amount}`)
+    ).toBeInTheDocument();
+  });
+
+  it('does not render when no estimated cost', () => {
+    render(<CartCost data-testid={testId} />, {
+      wrapper: ShopifyCartProvider(),
+    });
+
+    expect(screen.queryByTestId('cart-cost')).toBeNull();
+  });
+
+  it('renders a totalAmount when total is the amountType', () => {
+    render(<CartCost amountType="total" />, {
+      wrapper: ShopifyCartProvider({data: CART_WITH_LINES}),
+    });
+
+    expect(
+      screen.getByText(`CA$${CART_WITH_LINES.cost?.totalAmount?.amount}`)
+    ).toBeInTheDocument();
+  });
+
+  it('renders a subtotalAmount when subtotal is the amountType', () => {
+    render(<CartCost amountType="subtotal" />, {
+      wrapper: ShopifyCartProvider({data: CART_WITH_LINES}),
+    });
+
+    expect(
+      screen.getByText(`CA$${CART_WITH_LINES.cost?.subtotalAmount?.amount}`)
+    ).toBeInTheDocument();
+  });
+
+  it('renders a totalTaxAmount when tax is the amountType', () => {
+    render(<CartCost amountType="tax" />, {
+      wrapper: ShopifyCartProvider({data: CART_WITH_LINES}),
+    });
+
+    expect(
+      screen.getByText(`CA$${CART_WITH_LINES.cost?.totalTaxAmount?.amount}`)
+    ).toBeInTheDocument();
+  });
+
+  it('renders a totalDutyAmount when duty is the amountType', () => {
+    render(<CartCost amountType="duty" />, {
+      wrapper: ShopifyCartProvider({data: CART_WITH_LINES}),
+    });
+
+    expect(
+      screen.getByText(`CA$${CART_WITH_LINES.cost?.totalDutyAmount?.amount}`)
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/CartCost.tsx
+++ b/packages/react/src/CartCost.tsx
@@ -11,7 +11,7 @@ export interface CartCostProps {
 /**
  * The `CartCost` component renders a `Money` component with the
  * cost associated with the `amountType` prop. If no `amountType` prop is specified, then it defaults to `totalAmount`.
- * If `children` is a function, then it will pass down the render props provided by the parent component.
+Depends on `useCart()` and must be a child of `<CartProvider/>`
  */
 export function CartCost(
   props: Omit<React.ComponentProps<typeof Money>, 'data'> & CartCostProps

--- a/packages/react/src/CartCost.tsx
+++ b/packages/react/src/CartCost.tsx
@@ -4,7 +4,7 @@ import {useCart} from './CartProvider.js';
 export interface CartCostProps {
   /** A string type that defines the type of cost needed. Valid values: `total`, `subtotal`, `tax`, or `duty`. */
   amountType?: 'total' | 'subtotal' | 'tax' | 'duty';
-   /** Any `ReactNode` elements. */
+  /** Any `ReactNode` elements. */
   children?: React.ReactNode;
 }
 

--- a/packages/react/src/CartCost.tsx
+++ b/packages/react/src/CartCost.tsx
@@ -1,0 +1,42 @@
+import {Money} from './Money.js';
+import {useCart} from './CartProvider.js';
+
+export interface CartCostProps {
+  /** A string type that defines the type of cost needed. Valid values: `total`, `subtotal`, `tax`, or `duty`. */
+  amountType?: 'total' | 'subtotal' | 'tax' | 'duty';
+  /** A function that takes an object return by the `useMoney` hook and returns a `ReactNode`. */
+  children?: React.ReactNode;
+}
+
+/**
+ * The `CartCost` component renders a `Money` component with the
+ * cost associated with the `amountType` prop. If no `amountType` prop is specified, then it defaults to `totalAmount`.
+ * If `children` is a function, then it will pass down the render props provided by the parent component.
+ */
+export function CartCost(
+  props: Omit<React.ComponentProps<typeof Money>, 'data'> & CartCostProps
+) {
+  const {cost} = useCart();
+  const {amountType = 'total', children, ...passthroughProps} = props;
+  let amount;
+
+  if (amountType == 'total') {
+    amount = cost?.totalAmount;
+  } else if (amountType == 'subtotal') {
+    amount = cost?.subtotalAmount;
+  } else if (amountType == 'tax') {
+    amount = cost?.totalTaxAmount;
+  } else if (amountType == 'duty') {
+    amount = cost?.totalDutyAmount;
+  }
+
+  if (amount == null) {
+    return null;
+  }
+
+  return (
+    <Money {...passthroughProps} data={amount}>
+      {children}
+    </Money>
+  );
+}

--- a/packages/react/src/CartCost.tsx
+++ b/packages/react/src/CartCost.tsx
@@ -4,7 +4,7 @@ import {useCart} from './CartProvider.js';
 export interface CartCostProps {
   /** A string type that defines the type of cost needed. Valid values: `total`, `subtotal`, `tax`, or `duty`. */
   amountType?: 'total' | 'subtotal' | 'tax' | 'duty';
-  /** A function that takes an object return by the `useMoney` hook and returns a `ReactNode`. */
+   /** Any `ReactNode` elements. */
   children?: React.ReactNode;
 }
 


### PR DESCRIPTION
Moves the `CartCost` component over to HUI

### Additional context
Copied the CartCost component as is.
I redid the test for vitest and added a ladle story

I suspect we can improve the way we create mock carts in the future since we are all coupling a lot with one mock
