### PR TITLE
Add <AddToCartButton /> component

### DIFF
--- a/.changeset/gentle-jokes-search.md
+++ b/.changeset/gentle-jokes-search.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Adds the AddToCartButton component. This component renders a button that adds an item to the cart when pressed.

--- a/packages/react/src/AddToCartButton.stories.tsx
+++ b/packages/react/src/AddToCartButton.stories.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import type {Story} from '@ladle/react';
+import {AddToCartButton} from './AddToCartButton.js';
+import {CartProvider} from './CartProvider.js';
+import {ProductProvider} from './ProductProvider.js';
+import {getCartMock} from './CartProvider.test.helpers.js';
+import {getVariant, getProduct} from './ProductProvider.test.helpers.js';
+
+type AddToCartButtonProps = React.ComponentPropsWithoutRef<
+  typeof AddToCartButton
+>;
+
+const variant = getVariant();
+const cart = getCartMock();
+const product = getProduct();
+
+const Template: Story<AddToCartButtonProps> = (props) => {
+  return (
+    <ProductProvider data={product}>
+      <CartProvider data={cart}>
+        <AddToCartButton {...props}>Add to cart</AddToCartButton>
+      </CartProvider>
+    </ProductProvider>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  variantId: variant.id,
+};

--- a/packages/react/src/AddToCartButton.test.tsx
+++ b/packages/react/src/AddToCartButton.test.tsx
@@ -1,0 +1,207 @@
+import {vi} from 'vitest';
+import {CartProvider} from './CartProvider.js';
+import {render, screen, waitFor} from '@testing-library/react';
+import {ProductProvider} from './ProductProvider.js';
+import {AddToCartButton} from './AddToCartButton.js';
+import {getProduct, getVariant} from './ProductProvider.test.helpers.js';
+import {getCartMock} from './CartProvider.test.helpers.js';
+import userEvent from '@testing-library/user-event';
+
+const mockLinesAdd = vi.fn();
+
+vi.mock('./CartProvider', async () => ({
+  ...(await vi.importActual<Record<string, unknown>>('./CartProvider')),
+  useCart: () => ({
+    linesAdd: mockLinesAdd,
+  }),
+}));
+
+function MockWrapper({
+  children,
+  data: product,
+  initialVariantId,
+}: React.PropsWithChildren &
+  Partial<React.ComponentProps<typeof ProductProvider>>) {
+  const cart = getCartMock();
+  const mockProduct = getProduct();
+
+  return (
+    <ProductProvider
+      data={{...mockProduct, ...product}}
+      initialVariantId={initialVariantId}
+    >
+      <CartProvider data={cart}>{children}</CartProvider>
+    </ProductProvider>
+  );
+}
+
+describe('<AddToCartButton/>', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a button', () => {
+    render(
+      <MockWrapper>
+        <AddToCartButton variantId="123">Add to cart</AddToCartButton>
+      </MockWrapper>
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('Add to cart');
+  });
+
+  it('allows passthrough props', () => {
+    render(
+      <MockWrapper>
+        <AddToCartButton variantId="123" className="bg-blue-600">
+          Add to cart
+        </AddToCartButton>
+      </MockWrapper>
+    );
+
+    expect(screen.getByRole('button')).toHaveClass('bg-blue-600');
+  });
+
+  describe('when variantId is set explicity', () => {
+    it('renders a disabled button if the variantId is null', () => {
+      render(
+        <MockWrapper>
+          <AddToCartButton variantId={null}>Add to cart</AddToCartButton>
+        </MockWrapper>
+      );
+
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    it('calls linesAdd with the variantId', async () => {
+      const id = '123';
+      const user = userEvent.setup();
+
+      render(
+        <MockWrapper>
+          <AddToCartButton variantId={id}>Add to cart</AddToCartButton>
+        </MockWrapper>
+      );
+
+      await user.click(screen.getByRole('button'));
+
+      expect(mockLinesAdd).toHaveBeenCalledTimes(1);
+      expect(mockLinesAdd).toHaveBeenCalledWith([
+        expect.objectContaining({
+          merchandiseId: id,
+        }),
+      ]);
+    });
+  });
+
+  describe('when inside a ProductOptionsProvider', () => {
+    describe('and an initialVariantId is present', () => {
+      it('calls linesAdd with the initialVariantId', async () => {
+        const product = getProduct();
+        const selectedVariant = product?.variants?.nodes?.[0];
+        const user = userEvent.setup();
+
+        render(
+          <MockWrapper data={product} initialVariantId={selectedVariant?.id}>
+            <AddToCartButton>Add to cart</AddToCartButton>
+          </MockWrapper>
+        );
+
+        await user.click(screen.getByRole('button'));
+
+        expect(mockLinesAdd).toHaveBeenCalledTimes(1);
+        expect(mockLinesAdd).toHaveBeenCalledWith([
+          expect.objectContaining({
+            merchandiseId: selectedVariant?.id,
+          }),
+        ]);
+      });
+    });
+
+    describe('and the initialVariantId is omitted', () => {
+      it('calls linesAdd with the first available variant', async () => {
+        const product = getProduct({
+          variants: {
+            nodes: [
+              getVariant({
+                availableForSale: true,
+                id: 'some variant id',
+              }),
+            ],
+          },
+        });
+        const user = userEvent.setup();
+
+        render(
+          <MockWrapper data={product}>
+            <AddToCartButton>Add to cart</AddToCartButton>
+          </MockWrapper>
+        );
+
+        await user.click(screen.getByRole('button'));
+
+        expect(mockLinesAdd).toHaveBeenCalledTimes(1);
+        expect(mockLinesAdd).toHaveBeenCalledWith([
+          expect.objectContaining({
+            merchandiseId: 'some variant id',
+          }),
+        ]);
+      });
+    });
+
+    describe('and the initialVariantId is explicity set to null', () => {
+      it('disables the button', () => {
+        const product = getProduct();
+
+        render(
+          <MockWrapper data={product} initialVariantId={null}>
+            <AddToCartButton>Add to cart</AddToCartButton>
+          </MockWrapper>
+        );
+
+        expect(screen.getByRole('button')).toBeDisabled();
+      });
+    });
+
+    describe('when the button is clicked', () => {
+      it('disables the button', async () => {
+        const user = userEvent.setup();
+
+        render(
+          <MockWrapper>
+            <AddToCartButton variantId="123">Add to cart</AddToCartButton>
+          </MockWrapper>
+        );
+
+        user.click(screen.getByRole('button'));
+
+        await waitFor(() => {
+          expect(screen.getByRole('button')).toBeDisabled();
+        });
+      });
+
+      it('renders a message for screen readers when an accessible label is provided', async () => {
+        const user = userEvent.setup();
+
+        render(
+          <MockWrapper>
+            <AddToCartButton
+              accessibleAddingToCartLabel="Adding product to your cart"
+              variantId="123"
+            >
+              Add to cart
+            </AddToCartButton>
+          </MockWrapper>
+        );
+
+        user.click(screen.getByRole('button'));
+
+        await waitFor(() => {
+          expect(screen.getByRole('alert')).toHaveTextContent(
+            'Adding product to your cart'
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/react/src/AddToCartButton.test.tsx
+++ b/packages/react/src/AddToCartButton.test.tsx
@@ -94,7 +94,7 @@ describe('<AddToCartButton/>', () => {
     });
   });
 
-  describe('when inside a ProductOptionsProvider', () => {
+  describe('when inside a ProductProvider', () => {
     describe('and an initialVariantId is present', () => {
       it('calls linesAdd with the initialVariantId', async () => {
         const product = getProduct();

--- a/packages/react/src/AddToCartButton.tsx
+++ b/packages/react/src/AddToCartButton.tsx
@@ -1,0 +1,159 @@
+import {useCallback, useEffect, Ref, ReactNode, useState} from 'react';
+
+import {useCart} from './CartProvider.js';
+
+interface AddToCartButtonProps {
+  /** An array of cart line attributes that belong to the item being added to the cart. */
+  attributes?: {
+    key: string;
+    value: string;
+  }[];
+  /** The ID of the variant. */
+  variantId?: string | null;
+  /** The item quantity. */
+  quantity?: number;
+  /** The text that is announced by the screen reader when the item is being added to the cart. Used for accessibility purposes only and not displayed on the page. */
+  accessibleAddingToCartLabel?: string;
+  /** The selling plan ID of the subscription variant */
+  sellingPlanId?: string;
+}
+
+/**
+ * The `AddToCartButton` component renders a button that adds an item to the cart when pressed.
+ * It must be a descendent of the `CartProvider` component.
+ */
+export function AddToCartButton<AsType extends React.ElementType = 'button'>(
+  props: AddToCartButtonProps & BaseButtonProps<AsType>
+) {
+  const [addingItem, setAddingItem] = useState<boolean>(false);
+  const {
+    variantId = '',
+    quantity = 1,
+    attributes,
+    sellingPlanId,
+    onClick,
+    children,
+    accessibleAddingToCartLabel,
+    ...passthroughProps
+  } = props;
+  const {status, linesAdd} = useCart();
+  const disabled =
+    variantId === null ||
+    variantId === '' ||
+    addingItem ||
+    passthroughProps.disabled;
+
+  useEffect(() => {
+    if (addingItem && status === 'idle') {
+      setAddingItem(false);
+    }
+  }, [status, addingItem]);
+
+  const handleAddItem = useCallback(() => {
+    setAddingItem(true);
+    linesAdd([
+      {
+        quantity,
+        merchandiseId: variantId || '',
+        attributes,
+        sellingPlanId,
+      },
+    ]);
+  }, [linesAdd, quantity, variantId, attributes, sellingPlanId]);
+
+  return (
+    <>
+      <BaseButton
+        {...passthroughProps}
+        disabled={disabled}
+        onClick={onClick}
+        defaultOnClick={handleAddItem}
+      >
+        {children}
+      </BaseButton>
+      {accessibleAddingToCartLabel ? (
+        <p
+          style={{
+            position: 'absolute',
+            width: '1px',
+            height: '1px',
+            padding: '0',
+            margin: '-1px',
+            overflow: 'hidden',
+            clip: 'rect(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            borderWidth: '0',
+          }}
+          role="alert"
+          aria-live="assertive"
+        >
+          {addingItem ? accessibleAddingToCartLabel : null}
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+export interface CustomBaseButtonProps<AsType> {
+  /** Provide a React element or component to render as the underlying button. Note: for accessibility compliance, almost always you should use a `button` element, or a component that renders an underlying button. */
+  as?: AsType;
+  /** Any ReactNode elements. */
+  children: ReactNode;
+  /** Click event handler. Default behaviour triggers unless prevented */
+  onClick?: (
+    event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void | boolean;
+  /** A default onClick behavior */
+  defaultOnClick?: (
+    event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void | boolean;
+  /** A ref to the underlying button */
+  buttonRef?: Ref<HTMLButtonElement>;
+
+  disabled?: boolean;
+}
+
+export type BaseButtonProps<AsType extends React.ElementType> =
+  CustomBaseButtonProps<AsType> &
+    Omit<
+      React.ComponentPropsWithoutRef<AsType>,
+      keyof CustomBaseButtonProps<AsType>
+    >;
+
+export function BaseButton<AsType extends React.ElementType = 'button'>(
+  props: BaseButtonProps<AsType>
+) {
+  const {
+    as,
+    onClick,
+    defaultOnClick,
+    children,
+    buttonRef,
+    ...passthroughProps
+  } = props;
+
+  const handleOnClick = useCallback(
+    (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      if (onClick) {
+        const clickShouldContinue = onClick(event);
+        if (
+          (typeof clickShouldContinue === 'boolean' &&
+            clickShouldContinue === false) ||
+          event?.defaultPrevented
+        )
+          return;
+      }
+
+      defaultOnClick?.(event);
+    },
+    [defaultOnClick, onClick]
+  );
+
+  const Component = as || 'button';
+
+  return (
+    <Component ref={buttonRef} onClick={handleOnClick} {...passthroughProps}>
+      {children}
+    </Component>
+  );
+}

--- a/packages/react/src/AddToCartButton.tsx
+++ b/packages/react/src/AddToCartButton.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, Ref, ReactNode, useState} from 'react';
 
 import {useCart} from './CartProvider.js';
+import {useProduct} from './ProductProvider.js';
 
 interface AddToCartButtonProps {
   /** An array of cart line attributes that belong to the item being added to the cart. */
@@ -27,7 +28,7 @@ export function AddToCartButton<AsType extends React.ElementType = 'button'>(
 ) {
   const [addingItem, setAddingItem] = useState<boolean>(false);
   const {
-    variantId = '',
+    variantId: explicitVariantId,
     quantity = 1,
     attributes,
     sellingPlanId,
@@ -37,9 +38,12 @@ export function AddToCartButton<AsType extends React.ElementType = 'button'>(
     ...passthroughProps
   } = props;
   const {status, linesAdd} = useCart();
+  const {selectedVariant} = useProduct();
+  const variantId = explicitVariantId ?? selectedVariant?.id ?? '';
   const disabled =
-    variantId === null ||
+    explicitVariantId === null ||
     variantId === '' ||
+    selectedVariant === null ||
     addingItem ||
     passthroughProps.disabled;
 

--- a/packages/react/src/AddToCartButton.tsx
+++ b/packages/react/src/AddToCartButton.tsx
@@ -113,8 +113,6 @@ export interface CustomBaseButtonProps<AsType> {
   ) => void | boolean;
   /** A ref to the underlying button */
   buttonRef?: Ref<HTMLButtonElement>;
-
-  disabled?: boolean;
 }
 
 export type BaseButtonProps<AsType extends React.ElementType> =

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,4 @@
+export {AddToCartButton} from './AddToCartButton.js';
 export type {
   CartState,
   CartStatus,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Ports the AddToCartButton component from hydrogen. This component renders a button that adds an item to the cart when pressed.

### Additional context

https://github.com/Shopify/hydrogen/issues/1168

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen-ui/blob/main/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/). If you have a breaking change, it will need to wait until the next major version release. Otherwise, use patch updates even for new features. Read [more about Hydrogen-UI's versioning.](https://github.com/shopify/hydrogen-ui/blob/main/readme.md#versioning)
