### PR TITLE
Add BaseButton component

### DIFF
--- a/packages/react/src/AddToCartButton.tsx
+++ b/packages/react/src/AddToCartButton.tsx
@@ -1,7 +1,8 @@
-import {useCallback, useEffect, Ref, ReactNode, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 
 import {useCart} from './CartProvider.js';
 import {useProduct} from './ProductProvider.js';
+import {BaseButton, BaseButtonProps} from './BaseButton.js';
 
 interface AddToCartButtonProps {
   /** An array of cart line attributes that belong to the item being added to the cart. */
@@ -95,67 +96,5 @@ export function AddToCartButton<AsType extends React.ElementType = 'button'>(
         </p>
       ) : null}
     </>
-  );
-}
-
-export interface CustomBaseButtonProps<AsType> {
-  /** Provide a React element or component to render as the underlying button. Note: for accessibility compliance, almost always you should use a `button` element, or a component that renders an underlying button. */
-  as?: AsType;
-  /** Any ReactNode elements. */
-  children: ReactNode;
-  /** Click event handler. Default behaviour triggers unless prevented */
-  onClick?: (
-    event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => void | boolean;
-  /** A default onClick behavior */
-  defaultOnClick?: (
-    event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => void | boolean;
-  /** A ref to the underlying button */
-  buttonRef?: Ref<HTMLButtonElement>;
-}
-
-export type BaseButtonProps<AsType extends React.ElementType> =
-  CustomBaseButtonProps<AsType> &
-    Omit<
-      React.ComponentPropsWithoutRef<AsType>,
-      keyof CustomBaseButtonProps<AsType>
-    >;
-
-export function BaseButton<AsType extends React.ElementType = 'button'>(
-  props: BaseButtonProps<AsType>
-) {
-  const {
-    as,
-    onClick,
-    defaultOnClick,
-    children,
-    buttonRef,
-    ...passthroughProps
-  } = props;
-
-  const handleOnClick = useCallback(
-    (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      if (onClick) {
-        const clickShouldContinue = onClick(event);
-        if (
-          (typeof clickShouldContinue === 'boolean' &&
-            clickShouldContinue === false) ||
-          event?.defaultPrevented
-        )
-          return;
-      }
-
-      defaultOnClick?.(event);
-    },
-    [defaultOnClick, onClick]
-  );
-
-  const Component = as || 'button';
-
-  return (
-    <Component ref={buttonRef} onClick={handleOnClick} {...passthroughProps}>
-      {children}
-    </Component>
   );
 }

--- a/packages/react/src/BaseButton.test.tsx
+++ b/packages/react/src/BaseButton.test.tsx
@@ -1,0 +1,86 @@
+import {render, screen} from '@testing-library/react';
+import {BaseButton} from './BaseButton.js';
+import {vi} from 'vitest';
+import userEvent from '@testing-library/user-event';
+
+describe('<BaseButton/>', () => {
+  it('renders a button', () => {
+    render(<BaseButton>Base Button</BaseButton>);
+
+    expect(screen.getByRole('button')).toHaveTextContent('Base Button');
+  });
+
+  it('allows passthrough props', () => {
+    render(<BaseButton className="bg-blue-600">Base Button</BaseButton>);
+
+    expect(screen.getByRole('button')).toHaveClass('bg-blue-600');
+  });
+
+  describe('given an on click event handler', () => {
+    it('calls the on click event handler', async () => {
+      const mockOnClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(<BaseButton onClick={mockOnClick}>Base Button</BaseButton>);
+
+      await user.click(screen.getByRole('button'));
+
+      expect(mockOnClick).toHaveBeenCalled();
+    });
+
+    it('calls the given default on click behaviour', async () => {
+      const mockDefaultOnClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <BaseButton onClick={vi.fn()} defaultOnClick={mockDefaultOnClick}>
+          Base Button
+        </BaseButton>
+      );
+
+      await user.click(screen.getByRole('button'));
+
+      expect(mockDefaultOnClick).toHaveBeenCalled();
+    });
+
+    describe('and event preventDefault is called', () => {
+      it('calls the on click event handler without calling the default on click behaviour', async () => {
+        const mockOnClick = vi.fn((event) => {
+          event.preventDefault();
+        });
+        const mockDefaultOnClick = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+          <BaseButton onClick={mockOnClick} defaultOnClick={mockDefaultOnClick}>
+            Base Button
+          </BaseButton>
+        );
+
+        await user.click(screen.getByRole('button'));
+
+        expect(mockOnClick).toHaveBeenCalled();
+        expect(mockDefaultOnClick).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('and the on click handler returns false', () => {
+      it('calls the on click event handler without calling the default on click behaviour', async () => {
+        const mockOnClick = vi.fn(() => false);
+        const mockDefaultOnClick = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+          <BaseButton onClick={mockOnClick} defaultOnClick={mockDefaultOnClick}>
+            Base Button
+          </BaseButton>
+        );
+
+        await user.click(screen.getByRole('button'));
+
+        expect(mockOnClick).toHaveBeenCalled();
+        expect(mockDefaultOnClick).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/react/src/BaseButton.tsx
+++ b/packages/react/src/BaseButton.tsx
@@ -1,0 +1,63 @@
+import {ReactNode, Ref, useCallback} from 'react';
+
+export interface CustomBaseButtonProps<AsType> {
+  /** Provide a React element or component to render as the underlying button. Note: for accessibility compliance, almost always you should use a `button` element, or a component that renders an underlying button. */
+  as?: AsType;
+  /** Any ReactNode elements. */
+  children: ReactNode;
+  /** Click event handler. Default behaviour triggers unless prevented */
+  onClick?: (
+    event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void | boolean;
+  /** A default onClick behavior */
+  defaultOnClick?: (
+    event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void | boolean;
+  /** A ref to the underlying button */
+  buttonRef?: Ref<HTMLButtonElement>;
+}
+
+export type BaseButtonProps<AsType extends React.ElementType> =
+  CustomBaseButtonProps<AsType> &
+    Omit<
+      React.ComponentPropsWithoutRef<AsType>,
+      keyof CustomBaseButtonProps<AsType>
+    >;
+
+export function BaseButton<AsType extends React.ElementType = 'button'>(
+  props: BaseButtonProps<AsType>
+) {
+  const {
+    as,
+    onClick,
+    defaultOnClick,
+    children,
+    buttonRef,
+    ...passthroughProps
+  } = props;
+
+  const handleOnClick = useCallback(
+    (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      if (onClick) {
+        const clickShouldContinue = onClick(event);
+        if (
+          (typeof clickShouldContinue === 'boolean' &&
+            clickShouldContinue === false) ||
+          event?.defaultPrevented
+        )
+          return;
+      }
+
+      defaultOnClick?.(event);
+    },
+    [defaultOnClick, onClick]
+  );
+
+  const Component = as || 'button';
+
+  return (
+    <Component ref={buttonRef} onClick={handleOnClick} {...passthroughProps}>
+      {children}
+    </Component>
+  );
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Quick refactor to move the <BaseButton /> into a separate component file so that it can be shared with the other components that will soon be moved to this library. I also ported the tests.

### Additional context

https://github.com/Shopify/hydrogen/issues/1168

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen-ui/blob/main/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/). If you have a breaking change, it will need to wait until the next major version release. Otherwise, use patch updates even for new features. Read [more about Hydrogen-UI's versioning.](https://github.com/shopify/hydrogen-ui/blob/main/readme.md#versioning)
