### PR TITLE
Use BaseButton in CartCheckoutButton

### DIFF
--- a/packages/react/src/CartCheckoutButton.tsx
+++ b/packages/react/src/CartCheckoutButton.tsx
@@ -1,5 +1,6 @@
 import {ReactNode, useEffect, useState} from 'react';
 import {useCart} from './CartProvider.js';
+import {BaseButton, BaseButtonProps} from './BaseButton.js';
 
 type PropsWeControl = 'onClick';
 
@@ -8,7 +9,7 @@ type PropsWeControl = 'onClick';
  * It must be a descendent of a `CartProvider` component.
  */
 export function CartCheckoutButton(
-  props: Omit<JSX.IntrinsicElements['button'], PropsWeControl> & {
+  props: Omit<BaseButtonProps<'button'>, PropsWeControl> & {
     /** A `ReactNode` element. */
     children: ReactNode;
   }
@@ -24,12 +25,12 @@ export function CartCheckoutButton(
   }, [requestedCheckout, status, checkoutUrl]);
 
   return (
-    <button
+    <BaseButton
       {...passthroughProps}
       disabled={requestedCheckout || passthroughProps.disabled}
       onClick={() => setRequestedCheckout(true)}
     >
       {children}
-    </button>
+    </BaseButton>
   );
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Quick follow up to https://github.com/Shopify/hydrogen-ui/pull/60. This PR extends that component from the recently added BaseButton.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen-ui/blob/main/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/). If you have a breaking change, it will need to wait until the next major version release. Otherwise, use patch updates even for new features. Read [more about Hydrogen-UI's versioning.](https://github.com/shopify/hydrogen-ui/blob/main/readme.md#versioning)
