### PR TITLE
Add CartShopPayButton

### DIFF
--- a/.changeset/angry-hounds-love.md
+++ b/.changeset/angry-hounds-love.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Adds <CartShopPayButton /> that renders a ShopPayButton for items in the cart.

--- a/packages/react/src/BuyNowButton.test.tsx
+++ b/packages/react/src/BuyNowButton.test.tsx
@@ -3,7 +3,7 @@ import {render, screen} from '@testing-library/react';
 import {vi} from 'vitest';
 import userEvent from '@testing-library/user-event';
 import {BuyNowButton} from './BuyNowButton.js';
-import {getCartActionsMock} from './CartProvider.test.helpers.js';
+import {CartWithActions} from './cart-types.js';
 
 vi.mock('./CartProvider');
 
@@ -45,10 +45,12 @@ describe('<BuyNowButton/>', () => {
     it('uses useCartCreateCallback with the correct arguments', async () => {
       const mockCartCreate = vi.fn();
 
-      vi.mocked(useCart).mockImplementation(() => ({
-        ...getCartActionsMock(),
-        cartCreate: mockCartCreate,
-      }));
+      vi.mocked(useCart).mockImplementation(
+        () =>
+          ({
+            cartCreate: mockCartCreate as CartWithActions['cartCreate'],
+          } as ReturnType<typeof useCart>)
+      );
 
       const user = userEvent.setup();
 
@@ -119,10 +121,12 @@ describe('<BuyNowButton/>', () => {
     });
 
     it('redirects to checkout', () => {
-      vi.mocked(useCart).mockImplementation(() => ({
-        ...getCartActionsMock(),
-        checkoutUrl: '/checkout?id=123',
-      }));
+      vi.mocked(useCart).mockImplementation(
+        () =>
+          ({
+            checkoutUrl: '/checkout?id=123',
+          } as ReturnType<typeof useCart>)
+      );
 
       render(<BuyNowButton variantId="1">Buy now</BuyNowButton>, {
         wrapper: CartProvider,

--- a/packages/react/src/BuyNowButton.test.tsx
+++ b/packages/react/src/BuyNowButton.test.tsx
@@ -3,23 +3,9 @@ import {render, screen} from '@testing-library/react';
 import {vi} from 'vitest';
 import userEvent from '@testing-library/user-event';
 import {BuyNowButton} from './BuyNowButton.js';
+import {getCartActionsMock} from './CartProvider.test.helpers.js';
 
 vi.mock('./CartProvider');
-
-const defaultCart = {
-  buyerIdentityUpdate: vi.fn(),
-  cartAttributesUpdate: vi.fn(),
-  cartCreate: vi.fn(),
-  cartFragment: '',
-  checkoutUrl: '',
-  discountCodesUpdate: vi.fn(),
-  linesAdd: vi.fn(),
-  linesRemove: vi.fn(),
-  linesUpdate: vi.fn(),
-  noteUpdate: vi.fn(),
-  status: 'idle' as const,
-  totalQuantity: 0,
-};
 
 describe('<BuyNowButton/>', () => {
   it('renders a button', () => {
@@ -60,7 +46,7 @@ describe('<BuyNowButton/>', () => {
       const mockCartCreate = vi.fn();
 
       vi.mocked(useCart).mockImplementation(() => ({
-        ...defaultCart,
+        ...getCartActionsMock(),
         cartCreate: mockCartCreate,
       }));
 
@@ -134,7 +120,7 @@ describe('<BuyNowButton/>', () => {
 
     it('redirects to checkout', () => {
       vi.mocked(useCart).mockImplementation(() => ({
-        ...defaultCart,
+        ...getCartActionsMock(),
         checkoutUrl: '/checkout?id=123',
       }));
 

--- a/packages/react/src/CartProvider.test.helpers.ts
+++ b/packages/react/src/CartProvider.test.helpers.ts
@@ -81,18 +81,3 @@ export function getCartLineMock(
 ): PartialDeep<CartLine, {recurseIntoArrays: true}> {
   return {...CART_LINE, ...options};
 }
-
-export const getCartActionsMock = () => ({
-  buyerIdentityUpdate: vi.fn(),
-  cartAttributesUpdate: vi.fn(),
-  cartCreate: vi.fn(),
-  cartFragment: '',
-  checkoutUrl: '',
-  discountCodesUpdate: vi.fn(),
-  linesAdd: vi.fn(),
-  linesRemove: vi.fn(),
-  linesUpdate: vi.fn(),
-  noteUpdate: vi.fn(),
-  status: 'idle' as const,
-  totalQuantity: 0,
-});

--- a/packages/react/src/CartProvider.test.helpers.ts
+++ b/packages/react/src/CartProvider.test.helpers.ts
@@ -81,3 +81,18 @@ export function getCartLineMock(
 ): PartialDeep<CartLine, {recurseIntoArrays: true}> {
   return {...CART_LINE, ...options};
 }
+
+export const getCartActionsMock = () => ({
+  buyerIdentityUpdate: vi.fn(),
+  cartAttributesUpdate: vi.fn(),
+  cartCreate: vi.fn(),
+  cartFragment: '',
+  checkoutUrl: '',
+  discountCodesUpdate: vi.fn(),
+  linesAdd: vi.fn(),
+  linesRemove: vi.fn(),
+  linesUpdate: vi.fn(),
+  noteUpdate: vi.fn(),
+  status: 'idle' as const,
+  totalQuantity: 0,
+});

--- a/packages/react/src/CartShopPayButton.stories.tsx
+++ b/packages/react/src/CartShopPayButton.stories.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import type {Story} from '@ladle/react';
+import {CartShopPayButton} from './CartShopPayButton.js';
+import {CartProvider} from './CartProvider.js';
+import {getCartMock} from './CartProvider.test.helpers.js';
+
+type CartShopPayButtonProps = React.ComponentPropsWithoutRef<
+  typeof CartShopPayButton
+>;
+
+const cart = getCartMock();
+
+const Template: Story<CartShopPayButtonProps> = (props) => {
+  return (
+    <CartProvider data={cart}>
+      <CartShopPayButton {...props}>Add to cart</CartShopPayButton>
+    </CartProvider>
+  );
+};
+
+export const Default = Template.bind({});

--- a/packages/react/src/CartShopPayButton.test.tsx
+++ b/packages/react/src/CartShopPayButton.test.tsx
@@ -1,0 +1,34 @@
+import {CartShopPayButton} from './CartShopPayButton.js';
+import {CartProvider, useCart} from './CartProvider.js';
+import {render, screen} from '@testing-library/react';
+import {getCartMock} from './CartProvider.test.helpers.js';
+import {vi} from 'vitest';
+import {Cart} from './storefront-api-types.js';
+
+vi.mock('./CartProvider.js');
+
+vi.mock('./ShopPayButton.js', () => ({
+  ShopPayButton: (props: unknown) => (
+    <div data-testid="shop-pay-button">{JSON.stringify(props)}</div>
+  ),
+}));
+
+describe('CartShopPayButton', () => {
+  it('renders a ShopPayButton with the cart data', () => {
+    vi.mocked(useCart).mockImplementation(() => ({
+      lines: [{quantity: 2, merchandise: {id: '123'}}],
+    }));
+
+    render(<CartShopPayButton />, {wrapper: CartProvider});
+
+    const shopPayButton = screen.getAllByTestId('shop-pay-button');
+
+    expect(shopPayButton.length).toBe(1);
+
+    expect(
+      JSON.parse(shopPayButton.at(0)?.textContent as string)
+    ).toStrictEqual({
+      variantIdsAndQuantities: [{id: '123', quantity: 2}],
+    });
+  });
+});

--- a/packages/react/src/CartShopPayButton.test.tsx
+++ b/packages/react/src/CartShopPayButton.test.tsx
@@ -2,7 +2,6 @@ import {CartShopPayButton} from './CartShopPayButton.js';
 import {CartProvider, useCart} from './CartProvider.js';
 import {render, screen} from '@testing-library/react';
 import {vi} from 'vitest';
-import {getCartActionsMock} from './CartProvider.test.helpers.js';
 
 vi.mock('./CartProvider.js');
 
@@ -14,10 +13,12 @@ vi.mock('./ShopPayButton.js', () => ({
 
 describe('CartShopPayButton', () => {
   it('renders a ShopPayButton with the cart data', () => {
-    vi.mocked(useCart).mockImplementation(() => ({
-      ...getCartActionsMock(),
-      lines: [{quantity: 2, merchandise: {id: '123'}}],
-    }));
+    vi.mocked(useCart).mockImplementation(
+      () =>
+        ({
+          lines: [{quantity: 2, merchandise: {id: '123'}}],
+        } as ReturnType<typeof useCart>)
+    );
 
     render(<CartShopPayButton />, {wrapper: CartProvider});
 

--- a/packages/react/src/CartShopPayButton.test.tsx
+++ b/packages/react/src/CartShopPayButton.test.tsx
@@ -1,9 +1,8 @@
 import {CartShopPayButton} from './CartShopPayButton.js';
 import {CartProvider, useCart} from './CartProvider.js';
 import {render, screen} from '@testing-library/react';
-import {getCartMock} from './CartProvider.test.helpers.js';
 import {vi} from 'vitest';
-import {Cart} from './storefront-api-types.js';
+import {getCartActionsMock} from './CartProvider.test.helpers.js';
 
 vi.mock('./CartProvider.js');
 
@@ -16,6 +15,7 @@ vi.mock('./ShopPayButton.js', () => ({
 describe('CartShopPayButton', () => {
   it('renders a ShopPayButton with the cart data', () => {
     vi.mocked(useCart).mockImplementation(() => ({
+      ...getCartActionsMock(),
       lines: [{quantity: 2, merchandise: {id: '123'}}],
     }));
 

--- a/packages/react/src/CartShopPayButton.tsx
+++ b/packages/react/src/CartShopPayButton.tsx
@@ -1,0 +1,31 @@
+import {useMemo} from 'react';
+import {useCart} from './CartProvider.js';
+import {ShopPayButton} from './ShopPayButton.js';
+
+/**
+ * The `CartShopPayButton` component renders a `ShopPayButton` for the items in the cart.
+ * It must be a descendent of a `CartProvider` component.
+ */
+export function CartShopPayButton(
+  props: Omit<React.ComponentProps<typeof ShopPayButton>, 'variantIds'>
+) {
+  const {lines} = useCart();
+
+  const idsAndQuantities = useMemo(() => {
+    return lines?.map((line) => ({
+      id: line?.merchandise?.id || '',
+      quantity: line?.quantity || 1,
+    }));
+  }, [lines]);
+
+  if (!idsAndQuantities) {
+    return null;
+  }
+
+  return (
+    <ShopPayButton
+      variantIdsAndQuantities={idsAndQuantities}
+      {...props}
+    ></ShopPayButton>
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,7 @@ export type {
   CartAction,
 } from './cart-types.js';
 export {CartCheckoutButton} from './CartCheckoutButton.js';
+export {CartShopPayButton} from './CartShopPayButton.js';
 export {CartProvider, useCart} from './CartProvider.js';
 export {ExternalVideo} from './ExternalVideo.js';
 export {flattenConnection} from './flatten-connection.js';


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds `<CartShopPayButton />` that renders a ShopPayButton for items in the cart.

### Additional context

https://github.com/Shopify/hydrogen/issues/1168

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen-ui/blob/main/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/). If you have a breaking change, it will need to wait until the next major version release. Otherwise, use patch updates even for new features. Read [more about Hydrogen-UI's versioning.](https://github.com/shopify/hydrogen-ui/blob/main/readme.md#versioning)
