### PR TITLE
include xstate in builds

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,7 +54,12 @@
   "types": "./dist/types/index.d.ts",
   "unpkg": "./dist/umd/hydrogen-react.prod.js",
   "jsdelivr": "./dist/umd/hydrogen-react.prod.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "dist/dev/node_modules/use-sync-external-store/shim/with-selector.mjs",
+    "dist/prod/node_modules/use-sync-external-store/shim/with-selector.mjs",
+    "dist/dev/node_modules/use-sync-external-store/shim/with-selector.js",
+    "dist/prod/node_modules/use-sync-external-store/shim/with-selector.js"
+  ],
   "scripts": {
     "clean-dist": "rimraf ./dist",
     "dev": "run-s clean-dist dev:demo",

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -57,8 +57,7 @@ export default defineConfig(({mode}) => {
       minify: false,
       emptyOutDir: false,
       rollupOptions: {
-        // don't bundle these packages into our lib
-        external: (id, parentId) => {
+        external: (id) => {
           /**
            * Don't bundle these packages into our lib
            *
@@ -66,8 +65,8 @@ export default defineConfig(({mode}) => {
            * but if we wanted a browser esm build, we would either have to tell devs to use "import maps"
            * or to create a new bundle that doesn't use these as externals
            * */
-          if (parentId?.includes('@xstate') || id.includes('@xstate')) {
-            return true;
+          if (id.includes('xstate')) {
+            return false;
           }
 
           return externals.includes(id);


### PR DESCRIPTION
Previously, including xstate still caused issues in NextJS. How to reproduce:

1. Check out this repo and branch
2. `yarn`
3. `yarn dev`
4. open `localhost:3000`
5. Get error: `TypeError: _virtual_with_selector_mjs__WEBPACK_IMPORTED_MODULE_4__.w.exports.useSyncExternalStoreWithSelector is not a function`

<img width="1223" alt="Screenshot 2022-11-10 at 11 48 19 PM" src="https://user-images.githubusercontent.com/3054066/201280290-475fc8e3-5926-4e88-8199-a760c0b4de76.png">

---

With this update, we mark these files as having side effects, so that they aren't tree shaked from the bundle. These files modify the import of use-sync-external-store, so they can't be removed. This should fix the issues with NextJS