### PR TITLE
Add node-specific builds using Vite's --ssr flag

### DIFF
--- a/.changeset/two-birds-complain.md
+++ b/.changeset/two-birds-complain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Adds additional builds for Node-specific targets, to help ensure that server-side code was getting compiled for server-side runtimes, instead of browser-side code for server-side runtimes.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,28 +15,43 @@
     "dist",
     "storefront.schema.json"
   ],
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
+      "node": {
+        "require": {
+          "types": "./dist/types/index.d.cts",
+          "development": "./dist/node-dev/index.cjs",
+          "production": "./dist/node-prod/index.cjs",
+          "default": "./dist/node-prod/index.cjs"
+        },
+        "import": {
+          "types": "./dist/types/index.d.ts",
+          "development": "./dist/node-dev/index.js",
+          "production": "./dist/node-prod/index.js",
+          "default": "./dist/node-prod/index.js"
+        },
+        "default": "./dist/node-prod/index.cjs"
+      },
       "module": {
         "types": "./dist/types/index.d.ts",
-        "development": "./dist/dev/index.mjs",
-        "production": "./dist/prod/index.mjs",
-        "default": "./dist/prod/index.mjs"
+        "development": "./dist/browser-dev/index.js",
+        "production": "./dist/browser-prod/index.js",
+        "default": "./dist/browser-prod/index.js"
       },
       "import": {
         "types": "./dist/types/index.d.ts",
-        "development": "./dist/dev/index.mjs",
-        "production": "./dist/prod/index.mjs",
-        "default": "./dist/prod/index.mjs"
+        "development": "./dist/browser-dev/index.js",
+        "production": "./dist/browser-prod/index.js",
+        "default": "./dist/browser-prod/index.js"
       },
       "require": {
         "types": "./dist/types/index.d.cts",
-        "development": "./dist/dev/index.js",
-        "production": "./dist/prod/index.js",
-        "default": "./dist/prod/index.js"
+        "development": "./dist/browser-dev/index.cjs",
+        "production": "./dist/browser-prod/index.cjs",
+        "default": "./dist/browser-prod/index.cjs"
       },
-      "default": "./dist/prod/index.mjs"
+      "default": "./dist/browser-prod/index.js"
     },
     "./storefront-api-types": "./dist/types/storefront-api-types.d.ts",
     "./storefront.schema.json": "./storefront.schema.json",
@@ -55,21 +70,21 @@
   "unpkg": "./dist/umd/hydrogen-react.prod.js",
   "jsdelivr": "./dist/umd/hydrogen-react.prod.js",
   "sideEffects": [
-    "dist/dev/node_modules/use-sync-external-store/shim/with-selector.mjs",
-    "dist/prod/node_modules/use-sync-external-store/shim/with-selector.mjs",
-    "dist/dev/node_modules/use-sync-external-store/shim/with-selector.js",
-    "dist/prod/node_modules/use-sync-external-store/shim/with-selector.js"
+    "dist/*/node_modules/use-sync-external-store/shim/with-selector.*js"
   ],
   "scripts": {
     "clean-dist": "rimraf ./dist",
     "dev": "run-s clean-dist dev:demo",
     "dev:story": "ladle serve",
-    "dev:demo": "run-p dev:demo:*",
-    "dev:demo:vite": "vite build --watch --emptyOutDir false --clearScreen false --mode devbuild",
+    "dev:demo": "run-p dev:demo:* ",
+    "dev:demo:browser-dev": "vite build --watch --emptyOutDir false --clearScreen false --mode devbuild",
+    "dev:demo:node-dev": "vite build --watch --emptyOutDir false --clearScreen false --mode devbuild --ssr",
     "dev:demo:ts": "tsc --watch --emitDeclarationOnly",
     "build": "npm-run-all --sequential clean-dist --parallel build:vite:* build:tsc:es --parallel build:tsc:cjs copy-storefront-types",
-    "build:vite:dev": "vite build --mode devbuild",
-    "build:vite:prod": "vite build",
+    "build:vite:browser-dev": "vite build --mode devbuild",
+    "build:vite:browser-prod": "vite build",
+    "build:vite:node-dev": "vite build --mode devbuild --ssr",
+    "build:vite:node-prod": "vite build --ssr",
     "build:vite:umddev": "vite build --mode umdbuilddev",
     "build:vite:umdprod": "vite build --mode umdbuild",
     "build:tsc:cjs": "cpy ./dist/types/index.d.ts ./dist/types/ --rename='index.d.cts' --flat",

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,7 @@
       "outputs": ["dist/**"]
     },
     "dev": {
+      "dependsOn": ["^dev"],
       "cache": false
     },
     "//#lint": {},


### PR DESCRIPTION
Should help use the correct code for each environment in places where that's important, e.g. using node-specific stuff when in node.

Should also fix #65

<!-- Thank you for contributing! -->

### Description

Created new builds for node, and clarified that the already-existing builds are for browsers. Changed the package exports to match the new filesystem changes, and also updated the default to be back to `"type": "module"` as the issues have been ironed out there I believe. 

### Additional context

Here's how we're currently outputting builds now:


- node + cjs dev
- node + cjs prod
- node + esm dev
- node + esm prod
- browser - esm dev
- brower - esm prod

I don't believe we need a browser + cjs build, so we should be good there. 

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen-ui/blob/main/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/). If you have a breaking change, it will need to wait until the next major version release. Otherwise, use patch updates even for new features. Read [more about Hydrogen-UI's versioning.](https://github.com/shopify/hydrogen-ui/blob/main/readme.md#versioning)
