### PR TITLE
Update ShopifyProvider to have storeDomain match

### DIFF
--- a/.changeset/sharp-hornets-cover.md
+++ b/.changeset/sharp-hornets-cover.md
@@ -1,0 +1,25 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+`<ShopifyProvider/>` and `useShop()` updates:
+
+- Added a function `getShopifyDomain()` which will return a fully-qualified domain URL for your Shopify backend. For example:
+
+  ```ts
+  const {getShopifyDomain} = useShop();
+  console.log(getShopifyDomain());
+  // 'https://test.myshopify.com'
+  ```
+
+  This matches the function that was added to `createStorefrontClient()`.
+
+- ShopifyProvider's `storeDomain` prop can now accept the Shopify backend subdomain, matching how `createStorefrontClient()`'s `storeDomain` prop. ShopifyProvider still accepts a full domain, but that will be removed in a future breaking change.
+
+```tsx
+// preferred
+<ShopifyProvider shopifyConfig={{storeDomain: 'shop'}}></ShopifyProvider>
+
+// still works, but will be removed in the future
+<ShopifyProvider shopifyConfig={{storeDomain: 'shop.myshopify.com'}}></ShopifyProvider>
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ Processes that need to happen:
   - Also be careful that some versions of the Storefront API don't exactly match code here: for example, SFAPI `2022-07` could be both `2022-07` and `2022-7` in this codebase.
 - Run the `graphql-types` NPM script to generate the new types.
   - If there are new scalars, or scalars are removed, update the `codegen.yml` file's custom scalar settings and run the command again.
+- Search for all instances of `@deprecated` and see if it is time to make that breaking change
 - Run the `ci:checks` NPM script and fix any issues that may come up.
 - Manually update the `package.json` `version` to the latest. Note that you can't have a leading `0` in the version number, so for example Storefront API `2022-07` would have to be `2022.7.0`
 - Once you feel that everything is ready:

--- a/apps/nextjs/pages/_app.tsx
+++ b/apps/nextjs/pages/_app.tsx
@@ -6,7 +6,7 @@ export default function App({Component, pageProps}: AppProps) {
   return (
     <ShopifyProvider
       shopifyConfig={{
-        storeDomain: `hydrogen-preview.myshopify.com`,
+        storeDomain: `hydrogen-preview`,
         storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
         storefrontApiVersion: '2022-10',
         locale: 'EN-US',

--- a/packages/react/src/ShopifyProvider.test.tsx
+++ b/packages/react/src/ShopifyProvider.test.tsx
@@ -144,6 +144,105 @@ describe('<ShopifyProvider/>', () => {
       });
     });
   });
+
+  describe(`storeDomain`, () => {
+    it(`works with just the subdomain`, () => {
+      const {result} = renderHook(() => useShop(), {
+        wrapper: ({children}) => (
+          <ShopifyProvider
+            shopifyConfig={{
+              ...SHOPIFY_CONFIG,
+              storeDomain: 'notashop',
+            }}
+          >
+            {children}
+          </ShopifyProvider>
+        ),
+      });
+
+      expect(result.current.storeDomain).toBe('notashop');
+    });
+  });
+
+  describe(`getShopifyDomain()`, () => {
+    it(`works with just the subdomain`, () => {
+      const {result} = renderHook(() => useShop(), {
+        wrapper: ({children}) => (
+          <ShopifyProvider
+            shopifyConfig={{
+              ...SHOPIFY_CONFIG,
+              storeDomain: 'notashop',
+            }}
+          >
+            {children}
+          </ShopifyProvider>
+        ),
+      });
+
+      expect(result.current.getShopifyDomain()).toBe(
+        'https://notashop.myshopify.com'
+      );
+    });
+
+    it(`works with the domain`, () => {
+      // @deprecated to be removed when we no longer support passing in '.myshopify.com' for domainName
+      const {result} = renderHook(() => useShop(), {
+        wrapper: ({children}) => (
+          <ShopifyProvider
+            shopifyConfig={{
+              ...SHOPIFY_CONFIG,
+              storeDomain: 'notashop.myshopify.com',
+            }}
+          >
+            {children}
+          </ShopifyProvider>
+        ),
+      });
+
+      expect(result.current.getShopifyDomain()).toBe(
+        'https://notashop.myshopify.com'
+      );
+    });
+
+    it(`works with just the subdomain as override`, () => {
+      const {result} = renderHook(() => useShop(), {
+        wrapper: ({children}) => (
+          <ShopifyProvider
+            shopifyConfig={{
+              ...SHOPIFY_CONFIG,
+              storeDomain: 'notashop',
+            }}
+          >
+            {children}
+          </ShopifyProvider>
+        ),
+      });
+
+      expect(result.current.getShopifyDomain({storeDomain: 'test'})).toBe(
+        'https://test.myshopify.com'
+      );
+    });
+
+    it(`works with the domain as override`, () => {
+      // @deprecated to be removed when we no longer support passing in '.myshopify.com' for domainName
+      const {result} = renderHook(() => useShop(), {
+        wrapper: ({children}) => (
+          <ShopifyProvider
+            shopifyConfig={{
+              ...SHOPIFY_CONFIG,
+              storeDomain: 'notashop.myshopify.com',
+            }}
+          >
+            {children}
+          </ShopifyProvider>
+        ),
+      });
+
+      expect(
+        result.current.getShopifyDomain({storeDomain: 'test.myshopify.com'})
+      ).toBe('https://test.myshopify.com');
+    });
+  });
 });
 
 export function getShopifyConfig(

--- a/packages/react/src/metafield-parser.ts
+++ b/packages/react/src/metafield-parser.ts
@@ -25,6 +25,8 @@ import {flattenConnection} from './flatten-connection.js';
 export function metafieldParser<ReturnGeneric>(
   metafield: PartialDeep<MetafieldBaseType, {recurseIntoArrays: true}>
 ): ReturnGeneric {
+  // @deprecated this function will be renamed to 'parseMetafield()'
+
   if (!metafield.type) {
     const noTypeError = `metafieldParser(): The 'type' field is required in order to parse the Metafield.`;
     if (__HYDROGEN_DEV__) {


### PR DESCRIPTION
Add tests, and add some small notes to the upgrade guide.

<!-- Thank you for contributing! -->

### Description

Closes #73 by standardizing on `shopName`, while still allowing `shopName.myshopify.com` for the time being. That will be removed in a future breaking change. 

Also adds the `getShopifyDomain()` function as required in #73. 

### Additional context

And added some small notes for the next major bump. 

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen-ui/blob/main/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/). If you have a breaking change, it will need to wait until the next major version release. Otherwise, use patch updates even for new features. Read [more about Hydrogen-UI's versioning.](https://github.com/shopify/hydrogen-ui/blob/main/readme.md#versioning)
