### PR TITLE
add graphql comments, remove duplicated query, add new field names

### DIFF
--- a/.changeset/clever-plants-wink.md
+++ b/.changeset/clever-plants-wink.md
@@ -1,0 +1,9 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Added the `price` and `compareAtPrice` fields to our `defaultCartFragment`, which is used to get the Cart fields in the `<CartProvider />` component.
+
+The above fields should be identical to `priceV2` and `compareAtPriceV2`, with the exception that these `V2` fields are being deprecated in a future version of the Storefront API.
+
+We'll keep both for now, to help deveopers upgrade without issues, and then remove the `V2` versions in a future breaking update.

--- a/packages/react/src/CartProvider.tsx
+++ b/packages/react/src/CartProvider.tsx
@@ -28,6 +28,7 @@ import {
 import {useCartAPIStateMachine} from './useCartAPIStateMachine.js';
 import {CART_ID_STORAGE_KEY} from './cart-constants.js';
 import {PartialDeep} from 'type-fest';
+import {defaultCartFragment} from './cart-queries.js';
 
 export const CartContext = createContext<CartWithActions | null>(null);
 
@@ -133,7 +134,7 @@ export function CartProvider({
     data: cart,
     cartFragment,
     countryCode,
-    onCartActionEntry(context, event) {
+    onCartActionEntry(_, event) {
       try {
         switch (event.type) {
           case 'CART_CREATE':
@@ -525,104 +526,3 @@ function countryCodeNotUpdated(
       event.payload.buyerIdentity.countryCode
   );
 }
-
-export const defaultCartFragment = `
-fragment CartFragment on Cart {
-  id
-  checkoutUrl
-  totalQuantity
-  buyerIdentity {
-    countryCode
-    customer {
-      id
-      email
-      firstName
-      lastName
-      displayName
-    }
-    email
-    phone
-  }
-  lines(first: $numCartLines) {
-    edges {
-      node {
-        id
-        quantity
-        attributes {
-          key
-          value
-        }
-        cost {
-          totalAmount {
-            amount
-            currencyCode
-          }
-          compareAtAmountPerQuantity {
-            amount
-            currencyCode
-          }
-        }
-        merchandise {
-          ... on ProductVariant {
-            id
-            availableForSale
-            compareAtPriceV2 {
-              ...MoneyFragment
-            }
-            priceV2 {
-              ...MoneyFragment
-            }
-            requiresShipping
-            title
-            image {
-              ...ImageFragment
-            }
-            product {
-              handle
-              title
-            }
-            selectedOptions {
-              name
-              value
-            }
-          }
-        }
-      }
-    }
-  }
-  cost {
-    subtotalAmount {
-      ...MoneyFragment
-    }
-    totalAmount {
-      ...MoneyFragment
-    }
-    totalDutyAmount {
-      ...MoneyFragment
-    }
-    totalTaxAmount {
-      ...MoneyFragment
-    }
-  }
-  note
-  attributes {
-    key
-    value
-  }
-  discountCodes {
-    code
-  }
-}
-
-fragment MoneyFragment on MoneyV2 {
-  currencyCode
-  amount
-}
-fragment ImageFragment on Image {
-  id
-  url
-  altText
-  width
-  height
-}
-`;

--- a/packages/react/src/cart-queries.ts
+++ b/packages/react/src/cart-queries.ts
@@ -1,212 +1,258 @@
-export const CartLineAdd = (cartFragment: string) => `
-mutation CartLineAdd($cartId: ID!, $lines: [CartLineInput!]!, $numCartLines: Int = 250, $country: CountryCode = ZZ) @inContext(country: $country) {
-  cartLinesAdd(cartId: $cartId, lines: $lines) {
-    cart {
+export const CartLineAdd = (cartFragment: string) => /* GraphQL */ `
+  mutation CartLineAdd(
+    $cartId: ID!
+    $lines: [CartLineInput!]!
+    $numCartLines: Int = 250
+    $country: CountryCode = ZZ
+  ) @inContext(country: $country) {
+    cartLinesAdd(cartId: $cartId, lines: $lines) {
+      cart {
+        ...CartFragment
+      }
+    }
+  }
+
+  ${cartFragment}
+`;
+
+export const CartCreate = (cartFragment: string) => /* GraphQL */ `
+  mutation CartCreate(
+    $input: CartInput!
+    $numCartLines: Int = 250
+    $country: CountryCode = ZZ
+  ) @inContext(country: $country) {
+    cartCreate(input: $input) {
+      cart {
+        ...CartFragment
+      }
+    }
+  }
+
+  ${cartFragment}
+`;
+
+export const CartLineRemove = (cartFragment: string) => /* GraphQL */ `
+  mutation CartLineRemove(
+    $cartId: ID!
+    $lines: [ID!]!
+    $numCartLines: Int = 250
+    $country: CountryCode = ZZ
+  ) @inContext(country: $country) {
+    cartLinesRemove(cartId: $cartId, lineIds: $lines) {
+      cart {
+        ...CartFragment
+      }
+    }
+  }
+
+  ${cartFragment}
+`;
+
+export const CartLineUpdate = (cartFragment: string) => /* GraphQL */ `
+  mutation CartLineUpdate(
+    $cartId: ID!
+    $lines: [CartLineUpdateInput!]!
+    $numCartLines: Int = 250
+    $country: CountryCode = ZZ
+  ) @inContext(country: $country) {
+    cartLinesUpdate(cartId: $cartId, lines: $lines) {
+      cart {
+        ...CartFragment
+      }
+    }
+  }
+
+  ${cartFragment}
+`;
+
+export const CartNoteUpdate = (cartFragment: string) => /* GraphQL */ `
+  mutation CartNoteUpdate(
+    $cartId: ID!
+    $note: String
+    $numCartLines: Int = 250
+    $country: CountryCode = ZZ
+  ) @inContext(country: $country) {
+    cartNoteUpdate(cartId: $cartId, note: $note) {
+      cart {
+        ...CartFragment
+      }
+    }
+  }
+
+  ${cartFragment}
+`;
+
+export const CartBuyerIdentityUpdate = (cartFragment: string) => /* GraphQL */ `
+  mutation CartBuyerIdentityUpdate(
+    $cartId: ID!
+    $buyerIdentity: CartBuyerIdentityInput!
+    $numCartLines: Int = 250
+    $country: CountryCode = ZZ
+  ) @inContext(country: $country) {
+    cartBuyerIdentityUpdate(cartId: $cartId, buyerIdentity: $buyerIdentity) {
+      cart {
+        ...CartFragment
+      }
+    }
+  }
+
+  ${cartFragment}
+`;
+
+export const CartAttributesUpdate = (cartFragment: string) => /* GraphQL */ `
+  mutation CartAttributesUpdate(
+    $attributes: [AttributeInput!]!
+    $cartId: ID!
+    $numCartLines: Int = 250
+    $country: CountryCode = ZZ
+  ) @inContext(country: $country) {
+    cartAttributesUpdate(attributes: $attributes, cartId: $cartId) {
+      cart {
+        ...CartFragment
+      }
+    }
+  }
+
+  ${cartFragment}
+`;
+
+export const CartDiscountCodesUpdate = (cartFragment: string) => /* GraphQL */ `
+  mutation CartDiscountCodesUpdate(
+    $cartId: ID!
+    $discountCodes: [String!]
+    $numCartLines: Int = 250
+    $country: CountryCode = ZZ
+  ) @inContext(country: $country) {
+    cartDiscountCodesUpdate(cartId: $cartId, discountCodes: $discountCodes) {
+      cart {
+        ...CartFragment
+      }
+    }
+  }
+
+  ${cartFragment}
+`;
+
+export const CartQuery = (cartFragment: string) => /* GraphQL */ `
+  query CartQuery(
+    $id: ID!
+    $numCartLines: Int = 250
+    $country: CountryCode = ZZ
+  ) @inContext(country: $country) {
+    cart(id: $id) {
       ...CartFragment
     }
   }
-}
 
-${cartFragment}
+  ${cartFragment}
 `;
 
-export const CartCreate = (cartFragment: string) => `
-mutation CartCreate($input: CartInput!, $numCartLines: Int = 250, $country: CountryCode = ZZ) @inContext(country: $country) {
-  cartCreate(input: $input) {
-    cart {
-      ...CartFragment
-    }
-  }
-}
-
-${cartFragment}
-`;
-
-export const CartLineRemove = (cartFragment: string) => `
-mutation CartLineRemove($cartId: ID!, $lines: [ID!]!, $numCartLines: Int = 250, $country: CountryCode = ZZ) @inContext(country: $country) {
-  cartLinesRemove(cartId: $cartId, lineIds: $lines) {
-    cart {
-      ...CartFragment
-    }
-  }
-}
-
-${cartFragment}
-`;
-
-export const CartLineUpdate = (cartFragment: string) => `
-mutation CartLineUpdate($cartId: ID!, $lines: [CartLineUpdateInput!]!, $numCartLines: Int = 250, $country: CountryCode = ZZ) @inContext(country: $country) {
-  cartLinesUpdate(cartId: $cartId, lines: $lines) {
-    cart {
-      ...CartFragment
-    }
-  }
-}
-
-${cartFragment}
-`;
-
-export const CartNoteUpdate = (cartFragment: string) => `
-mutation CartNoteUpdate($cartId: ID!, $note: String, $numCartLines: Int = 250, $country: CountryCode = ZZ) @inContext(country: $country) {
-  cartNoteUpdate(cartId: $cartId, note: $note) {
-    cart {
-      ...CartFragment
-    }
-  }
-}
-
-${cartFragment}
-`;
-
-export const CartBuyerIdentityUpdate = (cartFragment: string) => `
-mutation CartBuyerIdentityUpdate(
-  $cartId: ID!
-  $buyerIdentity: CartBuyerIdentityInput!
-  $numCartLines: Int = 250
-  $country: CountryCode = ZZ
-) @inContext(country: $country) {
-  cartBuyerIdentityUpdate(cartId: $cartId, buyerIdentity: $buyerIdentity) {
-    cart {
-      ...CartFragment
-    }
-  }
-}
-
-${cartFragment}
-`;
-
-export const CartAttributesUpdate = (cartFragment: string) => `
-mutation CartAttributesUpdate($attributes: [AttributeInput!]!, $cartId: ID!, $numCartLines: Int = 250, $country: CountryCode = ZZ) @inContext(country: $country) {
-  cartAttributesUpdate(attributes: $attributes, cartId: $cartId) {
-    cart {
-      ...CartFragment
-    }
-  }
-}
-
-${cartFragment}
-`;
-
-export const CartDiscountCodesUpdate = (cartFragment: string) => `
-mutation CartDiscountCodesUpdate($cartId: ID!, $discountCodes: [String!], $numCartLines: Int = 250, $country: CountryCode = ZZ) @inContext(country: $country) {
-  cartDiscountCodesUpdate(cartId: $cartId, discountCodes: $discountCodes) {
-    cart {
-      ...CartFragment
-    }
-  }
-}
-
-${cartFragment}
-`;
-
-export const CartQuery = (cartFragment: string) => `
-query CartQuery($id: ID!, $numCartLines: Int = 250, $country: CountryCode = ZZ) @inContext(country: $country) {
-  cart(id: $id) {
-    ...CartFragment
-  }
-}
-
-${cartFragment}
-`;
-
-export const defaultCartFragment = `
-fragment CartFragment on Cart {
-  id
-  checkoutUrl
-  totalQuantity
-  buyerIdentity {
-    countryCode
-    customer {
-      id
-      email
-      firstName
-      lastName
-      displayName
-    }
-    email
-    phone
-  }
-  lines(first: $numCartLines) {
-    edges {
-      node {
+export const defaultCartFragment = /* GraphQL */ `
+  fragment CartFragment on Cart {
+    id
+    checkoutUrl
+    totalQuantity
+    buyerIdentity {
+      countryCode
+      customer {
         id
-        quantity
-        attributes {
-          key
-          value
-        }
-        cost {
-          totalAmount {
-            amount
-            currencyCode
+        email
+        firstName
+        lastName
+        displayName
+      }
+      email
+      phone
+    }
+    lines(first: $numCartLines) {
+      edges {
+        node {
+          id
+          quantity
+          attributes {
+            key
+            value
           }
-          compareAtAmountPerQuantity {
-            amount
-            currencyCode
+          cost {
+            totalAmount {
+              amount
+              currencyCode
+            }
+            compareAtAmountPerQuantity {
+              amount
+              currencyCode
+            }
           }
-        }
-        merchandise {
-          ... on ProductVariant {
-            id
-            availableForSale
-            compareAtPriceV2 {
-              ...MoneyFragment
-            }
-            priceV2 {
-              ...MoneyFragment
-            }
-            requiresShipping
-            title
-            image {
-              ...ImageFragment
-            }
-            product {
-              handle
-              title
+          merchandise {
+            ... on ProductVariant {
               id
-            }
-            selectedOptions {
-              name
-              value
+              availableForSale
+              compareAtPrice {
+                ...MoneyFragment
+              }
+              # @deprecated remove in next major
+              compareAtPriceV2 {
+                ...MoneyFragment
+              }
+              price {
+                ...MoneyFragment
+              }
+              # @deprecated remove in next major
+              priceV2 {
+                ...MoneyFragment
+              }
+              requiresShipping
+              title
+              image {
+                ...ImageFragment
+              }
+              product {
+                handle
+                title
+                id
+              }
+              selectedOptions {
+                name
+                value
+              }
             }
           }
         }
       }
     }
-  }
-  cost {
-    subtotalAmount {
-      ...MoneyFragment
+    cost {
+      subtotalAmount {
+        ...MoneyFragment
+      }
+      totalAmount {
+        ...MoneyFragment
+      }
+      totalDutyAmount {
+        ...MoneyFragment
+      }
+      totalTaxAmount {
+        ...MoneyFragment
+      }
     }
-    totalAmount {
-      ...MoneyFragment
+    note
+    attributes {
+      key
+      value
     }
-    totalDutyAmount {
-      ...MoneyFragment
-    }
-    totalTaxAmount {
-      ...MoneyFragment
+    discountCodes {
+      code
     }
   }
-  note
-  attributes {
-    key
-    value
-  }
-  discountCodes {
-    code
-  }
-}
 
-fragment MoneyFragment on MoneyV2 {
-  currencyCode
-  amount
-}
-fragment ImageFragment on Image {
-  id
-  url
-  altText
-  width
-  height
-}
+  fragment MoneyFragment on MoneyV2 {
+    currencyCode
+    amount
+  }
+  fragment ImageFragment on Image {
+    id
+    url
+    altText
+    width
+    height
+  }
 `;


### PR DESCRIPTION
Added the `price` and `compareAtPrice` fields to our `defaultCartFragment`, which is used to get the Cart fields in the `<CartProvider />` component.

The above fields should be identical to `priceV2` and `compareAtPriceV2`, with the exception that these `V2` fields are being deprecated in a future version of the Storefront API.

We'll keep both for now, to help deveopers upgrade without issues, and then remove the `V2` versions in a future breaking update.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen-ui/blob/main/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/). If you have a breaking change, it will need to wait until the next major version release. Otherwise, use patch updates even for new features. Read [more about Hydrogen-UI's versioning.](https://github.com/shopify/hydrogen-ui/blob/main/readme.md#versioning)
