### PR TITLE
round image resize width and height

### DIFF
--- a/packages/react/src/image-size.ts
+++ b/packages/react/src/image-size.ts
@@ -34,16 +34,19 @@ export function addImageSizeParametersToUrl({
     let finalWidth: string;
 
     if (typeof width === 'string') {
-      finalWidth = (IMG_SRC_SET_SIZES[0] * multipliedScale).toString();
+      finalWidth = Math.ceil(IMG_SRC_SET_SIZES[0] * multipliedScale).toString();
     } else {
-      finalWidth = (Number(width) * multipliedScale).toString();
+      finalWidth = Math.ceil(Number(width) * multipliedScale).toString();
     }
 
     newUrl.searchParams.append('width', finalWidth);
   }
 
   if (height && typeof height === 'number') {
-    newUrl.searchParams.append('height', (height * multipliedScale).toString());
+    newUrl.searchParams.append(
+      'height',
+      Math.ceil(height * multipliedScale).toString()
+    );
   }
 
   crop && newUrl.searchParams.append('crop', crop);


### PR DESCRIPTION
### Description

The math that is applied in the image component to create resize params for images served from cdn.shopify can generate float numbers. In this case the CDN is ignoring the params resulting in wrong generated images

[img](https://cdn.shopify.com/s/files/1/0551/5290/2227/products/A22PCA7940AAUN2441_72233_01.jpg?v=1671528772&width=270&height=337.5&crop=center) with float heght, that is not resized properly

the same image with integer height value, returned properly => [img](https://cdn.shopify.com/s/files/1/0551/5290/2227/products/A22PCA7940AAUN2441_72233_01.jpg?v=1671528772&width=270&height=338&crop=center)

### Additional context

We've added a Math.ceil to solve the problem

---
