### PR TITLE
Get flattenConnection return types better.

### DIFF
--- a/.changeset/wet-hounds-add.md
+++ b/.changeset/wet-hounds-add.md
@@ -35,3 +35,7 @@ The Storefront API changelog can be viewed [here](https://shopify.dev/api/releas
     ```
 
 - The `<Metafield/>` component has been removed; use `parseMetafield().parsedValue` to have control over what you want to render
+
+### Other Changes
+
+- The TypeScript types for the returned value of `flattenConnection()` should now be friendlier: if you are using a `PartialDeep` object, you'll still get a `PartialDeep` object in return; if you're NOT using a `PartialDeep` object, then the returned type will not be wrapped in `PartialDeep`.

--- a/packages/react/src/flatten-connection.test.ts
+++ b/packages/react/src/flatten-connection.test.ts
@@ -1,7 +1,8 @@
 import {PartialDeep} from 'type-fest';
-import {ProductConnection} from './storefront-api-types.js';
+import {ProductConnection, Product} from './storefront-api-types.js';
 import {flattenConnection} from './flatten-connection.js';
 import {vi} from 'vitest';
+import {expectType, TypeEqual} from 'ts-expect';
 
 describe('flattenConnection', () => {
   it('flattens legacy edges', () => {
@@ -71,5 +72,33 @@ describe('flattenConnection', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     expect(flattenConnection({})).toEqual([]);
     expect(console.warn).toHaveBeenCalled();
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it.skip(`has correct typescript types`, () => {
+    // works without PartialDeep
+    const type1 = flattenConnection({} as ProductConnection);
+    expectType<TypeEqual<typeof type1, Product[]>>(true);
+
+    // works with PartialDeep
+    const type2 = flattenConnection(
+      {} as PartialDeep<ProductConnection, {recurseIntoArrays: true}>
+    );
+    expectType<
+      TypeEqual<typeof type2, PartialDeep<Product[], {recurseIntoArrays: true}>>
+    >(true);
+
+    // works when passing the generic yourself + no PartialDeep
+    // @ts-expect-error empty object is expected here just for testing purposes
+    const type3 = flattenConnection<ProductConnection>({});
+    expectType<TypeEqual<typeof type3, Product[]>>(true);
+
+    // works when passing the generic yourself + PartialDeep
+    const type4 = flattenConnection<
+      PartialDeep<ProductConnection, {recurseIntoArrays: true}>
+    >({});
+    expectType<
+      TypeEqual<typeof type4, PartialDeep<Product[], {recurseIntoArrays: true}>>
+    >(true);
   });
 });


### PR DESCRIPTION
I was forced to use some `@ts-expect-errors` in order to get this to work, but to counter that I added some TypeScript tests to ensure the output is working as it should. 

Closes an issue on our project board. 